### PR TITLE
Use conda gfortran on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 env:
   global:
-    - CONDA_PREFIX=$HOME/miniconda
+    - CONDA_PREFIX=$HOME/conda
     - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda2-latest"
     - TRAVIS_PYTHON_VERSION="2.7"
 sudo: false
@@ -15,16 +15,21 @@ before_install:
     else
       OS="Linux-x86_64"
     fi
-  - curl $MINICONDA_URL_BASE-$OS.sh > $HOME/minconda.sh
-  - bash $HOME/minconda.sh -b -p $CONDA_PREFIX
+  - curl $MINICONDA_URL_BASE-$OS.sh > $HOME/miniconda.sh
+  - bash $HOME/miniconda.sh -b -p $CONDA_PREFIX
   - export PATH="$CONDA_PREFIX/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda install python=$TRAVIS_PYTHON_VERSION
-  - conda install gcc libgfortran cmake
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      conda install gcc libgfortran cmake
+    else
+      conda install gfortran_linux-64 cmake
+      export FC=$CONDA_PREFIX/bin/x86_64-conda_cos6-linux-gnu-gfortran
+    fi
 install:
-  - mkdir _build
-  - cd _build
+  - mkdir _build && cd _build
   - cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/../_install -DCMAKE_VERBOSE_MAKEFILE=True
   - make install
 before_script:

--- a/heat/bmi_heat.f90
+++ b/heat/bmi_heat.f90
@@ -17,8 +17,6 @@ module bmi_heat
        dimension (output_item_count) :: &
        output_items = (/'plate_surface__temperature'/)
 
-  private allocate_flattened_array, convert_indices
-
 contains
 
   ! Perform startup tasks for the model.
@@ -360,12 +358,12 @@ contains
     select case (var_name)
     case ('plate_surface__temperature')
        n_elements = self%n_y * self%n_x
-       call allocate_flattened_array(dest, n_elements)
+       allocate(dest(n_elements))
        dest = reshape(self%temperature, (/n_elements/))
        status = BMI_SUCCESS
     case default
        n_elements = 1
-       call allocate_flattened_array(dest, n_elements)
+       allocate(dest(n_elements))
        dest = -1.0
        status = BMI_FAILURE
     end select
@@ -394,14 +392,14 @@ contains
 
     select case (var_name)
     case ('plate_surface__temperature')
-       call allocate_flattened_array(dest, size(indices))
+       allocate(dest(size(indices)))
        do k = 1, size(indices)
           call convert_indices(k, indices, i, j, self%n_y)
           dest(k) = self%temperature(j,i)
        end do
        status = BMI_SUCCESS
     case default
-       call allocate_flattened_array(dest, 1)
+       allocate(dest(1))
        dest = -1.0
        status = BMI_FAILURE
     end select
@@ -442,16 +440,6 @@ contains
        status = BMI_FAILURE
     end select
   end function set_value_at_indices
-
-  ! A helper routine to allocate a flattened array.
-  subroutine allocate_flattened_array(array, n)
-    real, pointer, intent (inout) :: array(:)
-    integer, intent (in) :: n
-
-    if (.not.associated(array)) then
-       allocate(array(n))
-    end if
-  end subroutine allocate_flattened_array
 
   ! A helper for converting flattened to dimensional indices.
   subroutine convert_indices(k, indices, i, j, ny)

--- a/testing/get_value_test.f90
+++ b/testing/get_value_test.f90
@@ -10,7 +10,6 @@ program get_value_test
   character (len=BMI_MAXVARNAMESTR), pointer :: names(:)
   integer :: dims(2), locations(3)
   real, pointer :: z(:), y(:)
-  character(len=30) :: rowfmt
 
   write (*,"(a)",advance="no") "Initializing..."
   s = initialize(m, "")
@@ -21,7 +20,7 @@ program get_value_test
 
   s = get_var_grid(m, names(1), grid_id)
   s = get_grid_shape(m, grid_id, dims)
-  write(rowfmt,'(a,i4,a)') '(', dims(2), '(1x,f6.1))'
+  write (*,'(a,2i4)') 'Grid shape (ny,nx): ', dims
 
   write (*, "(a)") "Initial values:"
   s = get_value(m, "plate_surface__temperature", z)


### PR DESCRIPTION
The changes in this PR are very similar to those in https://github.com/csdms/bmi-fortran/pull/3, including the removal of the `allocate_flattened_array` helper function (which seems a bit hinky).